### PR TITLE
Remove Unnecessary Argument and Fix Typos for Data Transformation Implementation

### DIFF
--- a/ParticleNet/python/evalModels.py
+++ b/ParticleNet/python/evalModels.py
@@ -24,7 +24,6 @@ parser = argparse.ArgumentParser()
 parser.add_argument("--channel", type=str, required=True, help="channel")
 parser.add_argument("--signal", type=str, required=True, help="signal")
 parser.add_argument("--background", type=str, required=True, help="background")
-parser.add_argument("--penalty", default=0.3, help="lambda multiplied to the penalty")
 args = parser.parse_args()
 
 WORKDIR = os.environ['WORKDIR']
@@ -39,7 +38,7 @@ nClasses = 2
 max_epochs = 81
 
 def getChromosomes(SIG, BKG, top=10):
-    CSVFILE = f"{WORKDIR}/ParticleNet/results/{CHANNEL}/syne_tune_hpo/CSV/hpo_{SIG}_vs_{BKG}_penalty-{str(args.penalty).replace('.','p')}.csv"
+    CSVFILE = f"{WORKDIR}/ParticleNet/results/{CHANNEL}/syne_tune_hpo/CSV/hpo_{SIG}_vs_{BKG}.csv"
     df = pd.read_csv(CSVFILE)
     df = df.sort_values(by="objective", ascending=True)
     lst = df.to_dict(orient='records')

--- a/ParticleNet/python/launchHPO.py
+++ b/ParticleNet/python/launchHPO.py
@@ -55,7 +55,7 @@ tuner.run()
 experiment = load_experiment(tuner.name)
 results = experiment.results
 best_config = pd.DataFrame(experiment.best_config(), index=[0])
-outpath = f"results/{args.channel}/syne_tune_hpo/CSV/hpo_{args.signal}_vs_{args.background}_penalty-{str(args.penalty).replace('.','p')}.csv"
+outpath = f"results/{args.channel}/syne_tune_hpo/CSV/hpo_{args.signal}_vs_{args.background}.csv"
 os.makedirs(os.path.dirname(outpath), exist_ok=True)
 results.to_csv(outpath, index=False)
 best_config.to_csv(outpath.replace(".csv", "_best_config.csv"), index=False)

--- a/ParticleNet/python/trainModel.py
+++ b/ParticleNet/python/trainModel.py
@@ -88,7 +88,7 @@ def train(model, optimizer, scheduler, use_plateau_scheduler=False):
 
     total_loss = 0.
     for data in trainLoader:
-        transform_data(data.to(args.device))
+        data = transform_data(data.to(args.device))
         out = model(data.x, data.edge_index, data.graphInput, data.batch)
         optimizer.zero_grad()
         loss = F.cross_entropy(out, data.y)

--- a/ParticleNet/python/trainModel.py
+++ b/ParticleNet/python/trainModel.py
@@ -62,8 +62,6 @@ def transform_data(data):
     parity_mask = torch.rand(data.x.size(0), device=args.device) > 0.5
     data.x[parity_mask, 1:4] *= -1
 
-    return data
-
 #### load dataset
 logging.info("Start loading dataset")
 baseDir = f"{WORKDIR}/ParticleNet/dataset/{args.channel}__"
@@ -88,7 +86,7 @@ def train(model, optimizer, scheduler, use_plateau_scheduler=False):
 
     total_loss = 0.
     for data in trainLoader:
-        data = transform_data(data.to(args.device))
+        transform_data(data.to(args.device))
         out = model(data.x, data.edge_index, data.graphInput, data.batch)
         optimizer.zero_grad()
         loss = F.cross_entropy(out, data.y)

--- a/ParticleNet/python/trainModelSimple.py
+++ b/ParticleNet/python/trainModelSimple.py
@@ -67,8 +67,6 @@ def transform_data(data):
     parity_mask = torch.rand(data.x.size(0), device=args.device) > 0.5
     data.x[parity_mask, 1:4] *= -1
 
-    return data
-
 #### load dataset
 logging.info("Start loading dataset")
 baseDir = f"{WORKDIR}/ParticleNet/dataset/{args.channel}__"
@@ -93,7 +91,7 @@ def train(model, optimizer, scheduler, use_plateau_scheduler=False):
 
     total_loss = 0.
     for data in trainLoader:
-        data = transform_data(data.to(args.device))
+        transform_data(data.to(args.device))
         out = model(data.x, data.edge_index, data.graphInput, data.batch)
         optimizer.zero_grad()
         loss = F.cross_entropy(out, data.y.to(args.device))

--- a/ParticleNet/python/trainModelSimple.py
+++ b/ParticleNet/python/trainModelSimple.py
@@ -93,7 +93,7 @@ def train(model, optimizer, scheduler, use_plateau_scheduler=False):
 
     total_loss = 0.
     for data in trainLoader:
-        daata = transform_data(data.to(args.device))
+        data = transform_data(data.to(args.device))
         out = model(data.x, data.edge_index, data.graphInput, data.batch)
         optimizer.zero_grad()
         loss = F.cross_entropy(out, data.y.to(args.device))

--- a/ParticleNet/python/trainSglConfigForGA.py
+++ b/ParticleNet/python/trainSglConfigForGA.py
@@ -64,8 +64,6 @@ def transform_data(data):
     parity_mask = torch.rand(data.x.size(0), device=args.device) > 0.5
     data.x[parity_mask, 1:4] *= -1
 
-    return data
-
 #### load dataset
 logging.info("Start loading dataset")
 baseDir = f"{WORKDIR}/ParticleNet/dataset/{args.channel}__"
@@ -90,7 +88,7 @@ def train(model, optimizer, scheduler, use_plateau_scheduler=False):
 
     total_loss = 0.
     for data in trainLoader:
-        data = transform_data(data.to(args.device))
+        transform_data(data.to(args.device))
         out = model(data.x, data.edge_index, data.graphInput, data.batch)
         optimizer.zero_grad()
         loss = F.cross_entropy(out, data.y)

--- a/ParticleNet/python/trainSglConfigForGA.py
+++ b/ParticleNet/python/trainSglConfigForGA.py
@@ -90,7 +90,7 @@ def train(model, optimizer, scheduler, use_plateau_scheduler=False):
 
     total_loss = 0.
     for data in trainLoader:
-        transform_data(data.to(args.device))
+        data = transform_data(data.to(args.device))
         out = model(data.x, data.edge_index, data.graphInput, data.batch)
         optimizer.zero_grad()
         loss = F.cross_entropy(out, data.y)


### PR DESCRIPTION
1. Remove parts related to `arg.penalty` since we don't need it anymore.
2. Fix some typos in `python/train*.py` to ensure proper implementation of `transform_data`.
3. I didn't upload the results of the previous training w/ syne_tune. Please let me know if you need.